### PR TITLE
Mobile fixes

### DIFF
--- a/_includes/article.liquid
+++ b/_includes/article.liquid
@@ -6,24 +6,24 @@ layout: default
 
 {{ content }}
 
-<p>
-<b>Published:</b> {% dateFormat published %}<br/>
-{% if author %}
-<b>Author:</b> {{ author }}<br/>
-{% endif %}
-{% if moreinfo %}
-<b>More Information:</b> <a href="{{moreinfo}}">{{moreinfo}}</a><br/>
-{% endif %}
-{% if sourceurl %}
-<b>Source:</b> <a href="{{sourceurl}}">{{sourceurl}}</a><br/>
-{% endif %}
-{% if tags %}
-<b>Tags:</b>
-	{% for tag in tags %}
-	<a href="/tag/{{tag | cgi_escape}}"><span class="label label-info">{{tag}}</span></a>
-	{% endfor %}
-{% endif %}
-</p>
+<div class="mb-5 p-2 break-long-text">
+    <b>Published:</b> {% dateFormat published %}<br/>
+    {% if author %}
+    <b>Author:</b> {{ author }}<br/>
+    {% endif %}
+    {% if moreinfo %}
+    <b>More Information:</b> <a href="{{moreinfo}}">{{moreinfo}}</a><br/>
+    {% endif %}
+    {% if sourceurl %}
+    <b>Source:</b> <a href="{{sourceurl}}">{{sourceurl}}</a><br/>
+    {% endif %}
+    {% if tags %}
+    <b>Tags:</b>
+        {% for tag in tags %}
+        <a href="/tag/{{tag | cgi_escape}}"><span class="label label-info">{{tag}}</span></a>
+        {% endfor %}
+    {% endif %}
+</div>
 
 <div id="disqus_thread"></div>
     <script type="text/javascript">
@@ -31,7 +31,7 @@ layout: default
         var disqus_shortname = 'javascriptcookbook'; // required: replace example with your forum shortname
 		var disqus_url = 'http://www.javascriptcookbook.com/article/{{sesURL}}';
 		var disqus_identifer = '{{id}}';
-		
+
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
@@ -41,4 +41,3 @@ layout: default
     </script>
     <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
-    

--- a/_includes/default.liquid
+++ b/_includes/default.liquid
@@ -1,6 +1,8 @@
 <!doctype html>
 <html lang="en">
     <head>
+    <meta charset="utf8">
+    <meta name="viewport" content="width=device-width">
     <title>{{title}}</title>
     <link rel="stylesheet" href="/css/bootstrap.min.css" type="text/css" />
     <link rel="stylesheet" href="/css/app.css" type="text/css" />
@@ -11,7 +13,7 @@
     <link rel="stylesheet" href="/css/prism.css" />
     <link rel="alternate" type="application/rss+xml" title="RSS" href="https://www.javascriptcookbook.com/rss" />
     </head>
-    
+
     <body>
 
     <main role="main" class="container">
@@ -44,7 +46,7 @@
       </nav>
 
       <div class="container">
-      {{content}} 
+      {{content}}
       </div>
     </main>
 

--- a/_includes/default.liquid
+++ b/_includes/default.liquid
@@ -16,7 +16,7 @@
 
     <body>
 
-    <main role="main" class="container">
+    <main role="main" class="container-fluid px-0">
 
       <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
         <a class="navbar-brand" href="/">JavaScript Cookbook</a>
@@ -45,7 +45,7 @@
         </div>
       </nav>
 
-      <div class="container">
+      <div class="container pb-3">
       {{content}}
       </div>
     </main>

--- a/css/app.css
+++ b/css/app.css
@@ -6,3 +6,13 @@ body {
 div.container {
 	margin-top:20px;
 }
+
+@media screen and (max-width: 575px) {
+	.indexTags {
+		flex-direction: row !important;
+	}
+
+	.indexTags li:first-child {
+		flex: 1 1 100%;
+	}
+}

--- a/css/app.css
+++ b/css/app.css
@@ -1,5 +1,6 @@
 body {
-margin-top:20px;	
+	margin: 0;
+	padding: 0;
 }
 
 div.container {

--- a/css/app.css
+++ b/css/app.css
@@ -7,6 +7,17 @@ div.container {
 	margin-top:20px;
 }
 
+.break-long-text {
+	overflow-x: hidden;
+	-ms-word-break: break-all;
+	word-break: break-all;
+	word-break: break-word; /* Non standard for WebKit */
+	-webkit-hyphens: auto;
+	-moz-hyphens: auto;
+	hyphens: auto;
+}
+
+
 @media screen and (max-width: 575px) {
 	.indexTags {
 		flex-direction: row !important;

--- a/index.liquid
+++ b/index.liquid
@@ -4,34 +4,33 @@ title: JavaScript Cookbook
 ---
 
 <div class="row">
-  <div class="col-10">
+  <article class="col-sm-8 col-md-9 col-lg-10 mb-5">
       <h2>Welcome</h2>
 
       <p class="lead">
-      The JavaScript Cookbook is a site for common JavaScript problems and solutions. Anyone is 
-      welcome to <a href="/submit">contribute</a> an article. 
-      </p>    
-      
+      The JavaScript Cookbook is a site for common JavaScript problems and solutions. Anyone is
+      welcome to <a href="/submit">contribute</a> an article.
+      </p>
+
       <h3>Updates</h3>
       <p>
-      It's been four years since the last update. The site is now built using <a href="https://11ty.io">11ty</a>, search is local, 
+      It's been four years since the last update. The site is now built using <a href="https://11ty.io">11ty</a>, search is local,
       and I'm using PRs for submissions.
       </p>
-      
+
       <h3>Latest Articles</h3>
 
     {% for article in collections.articles limit:5 %}
       <a href="{{article.url}}">{{ article.data.title }}</a> - {% dateFormat article.data.published %}<br/>
     {% endfor %}
 
-  </div>
-  <div class="col-2">
-    <ul class="nav flex-column bg-light">
+  </article>
+  <aside class="col-sm-4 col-md-3 col-lg-2">
+    <ul class="indexTags nav flex-column bg-light">
       <li class="nav-link">Tags</li>
-    {% for tag in collections.tagList %}
-    <li class="nav-link"><a href="/tag/{{tag | cgi_escape}}">{{ tag }}</a></li>
-    {% endfor %}
-    </ul>   
-  </div>
+      {% for tag in collections.tagList %}
+      <li class="nav-link"><a href="/tag/{{tag | cgi_escape}}">{{ tag }}</a></li>
+      {% endfor %}
+    </ul>
+  </aside>
 </div>
-


### PR DESCRIPTION
Mobile was broken due to missing meta viewport.
As consequence of adding it, had to address also:
- tags sidebar overflow and too narrow on some screen widths;
- article infos URL sometimes broke layout due to long urls;
As personal preference, removed body margin so that the site header extends the entire window width.